### PR TITLE
(feature) provide option to allow sloppy moves

### DIFF
--- a/chess.js
+++ b/chess.js
@@ -1838,7 +1838,7 @@ export const Chess = function (fen) {
       if (typeof move === 'string') {
         move_obj = move_from_san(move, sloppy)
       } else if (typeof move === 'object') {
-        var moves = generate_moves()
+        var moves = generate_moves({ legal: !sloppy });
 
         /* convert the pretty move object to an ugly move object */
         for (var i = 0, len = moves.length; i < len; i++) {


### PR DESCRIPTION
Providing the facility to allow a sloppy (illegal) move on an individual basis by passing in the option `{ sloppy: true }`. e.g.

```
chess.move({ from, to }, { sloppy: true });
```